### PR TITLE
Chapter 1 Automate fixed for more modern versions of node

### DIFF
--- a/Ch1/automate/gulpfile.js
+++ b/Ch1/automate/gulpfile.js
@@ -4,7 +4,6 @@ var gulp = require('gulp');
 var sass = require('gulp-dart-sass');
 var sourcemaps = require('gulp-sourcemaps');
 var autoprefixer = require('gulp-autoprefixer');
-
  
 gulp.task('sass', function () {
  return gulp.src('sass/*.scss')
@@ -12,18 +11,10 @@ gulp.task('sass', function () {
   .pipe(sourcemaps.init('/maps'))
   .pipe(sass().on('error', sass.logError))
   .pipe(sourcemaps.write('./maps'))
-  .pipe(gulp.dest('./css'));
+  .pipe(gulp.dest('./css'))
+  .on('finish', () => console.log('SASS invoked and finished successfully'));
 });      
 
 gulp.task('default', function () {
-  gulp.watch('sass/*.scss', ['sass'])
-  .on('change', function(evt) {
-    console.log(
-      '\n[watcher] File ' + evt.path.replace(/.*(?=sass)/,'') + 
-      ' was ' + evt.type + ', compiling...'
-    );
-  });
+  gulp.watch('sass/*.scss', gulp.series('sass'));
 });
-
-
-	

--- a/Ch1/automate/package.json
+++ b/Ch1/automate/package.json
@@ -10,7 +10,7 @@
   "author": "",
   "license": "ISC",
   "devDependencies": {
-    "gulp": "^3.9.1",
+    "gulp": "^4.0.2",
     "gulp-autoprefixer": "^5.0.0",
     "gulp-dart-sass": "^0.9.0",
     "gulp-sourcemaps": "^2.6.4"


### PR DESCRIPTION
More modern versions of node require gulp 4 or above, running the code as is won't work. This change fixes the issue but loses the console message - someone might want to add it again, but I don't know how to.